### PR TITLE
#7 Settings - links in result message

### DIFF
--- a/asset/sql/structure.sql
+++ b/asset/sql/structure.sql
@@ -60,3 +60,16 @@ CREATE TABLE `better_location_static_map_cache` (
   `url` text NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
+CREATE TABLE IF NOT EXISTS better_location_chat_services
+(
+    id         int auto_increment primary key,
+    chat_id    int NOT NULL,
+    service_id int NOT NULL,
+    type       int NOT NULL COMMENT 'Share, Drive, Screenshot, ...',
+    `order`    int NOT NULL,
+    constraint better_location_chat_services_unique_order
+        unique (chat_id, type, `order`),
+    constraint better_location_chat_services_unique_services
+        unique (chat_id, service_id, type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+

--- a/src/libs/BetterLocation/BetterLocation.php
+++ b/src/libs/BetterLocation/BetterLocation.php
@@ -166,12 +166,11 @@ class BetterLocation
 		}
 	}
 
-	public function generateMessage(BetterLocationMessageSettings $settings = null): string
+	public function generateMessage(BetterLocationMessageSettings $settings): string
 	{
-		$settings = new BetterLocationMessageSettings(); // @TODO load from database if available
 		$text = sprintf('%s <a href="%s" target="_blank">%s</a> <code>%s</code>',
 			$this->prefixMessage,
-			$this->generateScreenshotLink($settings->screenshotLinkService),
+			$this->generateScreenshotLink($settings->getScreenshotLinkService()),
 			Icons::MAP_SCREEN,
 			$this->__toString()
 		);
@@ -186,7 +185,7 @@ class BetterLocation
 				$this->pregeneratedLinks[$service] ?? $service::getLink($this->lat, $this->lon),
 				$service::getName(true),
 			);
-		}, $settings->linkServices);
+		}, $settings->getLinkServices());
 		// Add to favourites
 		$textLinks[] = sprintf('<a href="%s" target="_blank">%s</a>',
 			TelegramHelper::generateStart(sprintf('%s %s %s %s', StartCommand::FAVOURITE, StartCommand::FAVOURITE_ADD, $this->getLat(), $this->getLon())),
@@ -194,7 +193,7 @@ class BetterLocation
 		);
 		$text .= join(' | ', $textLinks) . PHP_EOL;
 
-		if ($settings->address && is_null($this->address) === false) {
+		if ($settings->showAddress() && is_null($this->address) === false) {
 			$text .= $this->getAddress() . PHP_EOL;
 		}
 
@@ -206,11 +205,10 @@ class BetterLocation
 	}
 
 	/** @return Types\Inline\Keyboard\Button[] */
-	public function generateDriveButtons(BetterLocationMessageSettings $settings = null): array
+	public function generateDriveButtons(BetterLocationMessageSettings $settings): array
 	{
-		$settings = new BetterLocationMessageSettings(); // @TODO load from database if available
 		$buttons = [];
-		foreach ($settings->buttonServices as $service) {
+		foreach ($settings->getButtonServices() as $service) {
 			$button = new Types\Inline\Keyboard\Button();
 			$button->text = sprintf('%s %s', $service::getName(true), Icons::CAR);
 			$button->url = $service::getLink($this->lat, $this->lon, true);

--- a/src/libs/BetterLocation/Service/BetterLocationService.php
+++ b/src/libs/BetterLocation/Service/BetterLocationService.php
@@ -9,6 +9,7 @@ use App\Utils\Coordinates;
 
 final class BetterLocationService extends AbstractService
 {
+	const ID = 1;
 	const NAME = 'BetterLocation';
 
 	const LINK = 'https://better-location.palider.cz';

--- a/src/libs/BetterLocation/Service/Coordinates/MGRSService.php
+++ b/src/libs/BetterLocation/Service/Coordinates/MGRSService.php
@@ -11,6 +11,7 @@ use Tracy\ILogger;
 
 final class MGRSService extends AbstractService
 {
+	const ID = 14;
 	const NAME = 'MGRS';
 
 	public static function findInText(string $text): BetterLocationCollection

--- a/src/libs/BetterLocation/Service/Coordinates/USNGService.php
+++ b/src/libs/BetterLocation/Service/Coordinates/USNGService.php
@@ -11,6 +11,7 @@ use Tracy\ILogger;
 
 final class USNGService extends AbstractService
 {
+	const ID = 13;
 	const NAME = 'USNG';
 
 	public static function findInText(string $text): BetterLocationCollection

--- a/src/libs/BetterLocation/Service/Coordinates/WGS84DegreesMinutesSecondsService.php
+++ b/src/libs/BetterLocation/Service/Coordinates/WGS84DegreesMinutesSecondsService.php
@@ -6,6 +6,7 @@ use App\Utils\Coordinates;
 
 final class WGS84DegreesMinutesSecondsService extends AbstractService
 {
+	const ID = 12;
 	const RE_COORD = '([0-9]{1,3})[° ]{1,3}([0-9]{1,2})[\' ]{1,3}([0-9]{1,3}(?:\.[0-9]{1,20})?)[\" ]{0,2}';
 	const NAME = 'WGS84 DMS';
 

--- a/src/libs/BetterLocation/Service/Coordinates/WGS84DegreesMinutesService.php
+++ b/src/libs/BetterLocation/Service/Coordinates/WGS84DegreesMinutesService.php
@@ -6,8 +6,9 @@ use App\Utils\Coordinates;
 
 final class WGS84DegreesMinutesService extends AbstractService
 {
-	const RE_COORD = '([0-9]{1,3})[° ]{1,3}([0-9]{1,3}\.[0-9]{1,20}) ?\'?';
+	const ID = 11;
 	const NAME = 'WGS84 DM';
+	const RE_COORD = '([0-9]{1,3})[° ]{1,3}([0-9]{1,3}\.[0-9]{1,20}) ?\'?';
 
 	public function process(): void
 	{

--- a/src/libs/BetterLocation/Service/Coordinates/WGS84DegreesService.php
+++ b/src/libs/BetterLocation/Service/Coordinates/WGS84DegreesService.php
@@ -6,8 +6,9 @@ use App\Utils\Coordinates;
 
 final class WGS84DegreesService extends AbstractService
 {
-	const RE_COORD = '([0-9]{1,3}\.[0-9]{1,20})';
+	const ID = 10;
 	const NAME = 'WGS84';
+	const RE_COORD = '([0-9]{1,3}\.[0-9]{1,20})';
 
 	public function process(): void
 	{

--- a/src/libs/BetterLocation/Service/DrobnePamatkyCzService.php
+++ b/src/libs/BetterLocation/Service/DrobnePamatkyCzService.php
@@ -13,6 +13,7 @@ use Tracy\ILogger;
 
 final class DrobnePamatkyCzService extends AbstractService
 {
+	const ID = 16;
 	const NAME = 'DrobnePamatky.cz';
 
 	const LINK = 'https://www.drobnepamatky.cz';

--- a/src/libs/BetterLocation/Service/DuckDuckGoService.php
+++ b/src/libs/BetterLocation/Service/DuckDuckGoService.php
@@ -23,7 +23,7 @@ final class DuckDuckGoService extends AbstractService
 
 	public function isValid(): bool
 	{
-		throw new NotImplementedException('Validating is not implemented.');
+		return false; // Currently not implemented
 	}
 
 	public function process()

--- a/src/libs/BetterLocation/Service/DuckDuckGoService.php
+++ b/src/libs/BetterLocation/Service/DuckDuckGoService.php
@@ -6,6 +6,7 @@ use App\BetterLocation\Service\Exceptions\NotImplementedException;
 
 final class DuckDuckGoService extends AbstractService
 {
+	const ID = 21;
 	const NAME = 'DuckDuckGo';
 	const NAME_SHORT = 'DDG';
 

--- a/src/libs/BetterLocation/Service/FacebookService.php
+++ b/src/libs/BetterLocation/Service/FacebookService.php
@@ -12,6 +12,7 @@ use Nette\Http\Url;
 
 final class FacebookService extends AbstractService
 {
+	const ID = 6;
 	const NAME = 'Facebook';
 
 	const LINK = 'https://facebook.com';

--- a/src/libs/BetterLocation/Service/FevGamesService.php
+++ b/src/libs/BetterLocation/Service/FevGamesService.php
@@ -13,6 +13,7 @@ use Tracy\Debugger;
 
 final class FevGamesService extends AbstractService
 {
+	const ID = 24;
 	const NAME = 'FevGames';
 
 	const LINK = 'https://fevgames.net';

--- a/src/libs/BetterLocation/Service/FirmyCzService.php
+++ b/src/libs/BetterLocation/Service/FirmyCzService.php
@@ -9,6 +9,7 @@ use DJTommek\MapyCzApi\MapyCzApi;
 
 final class FirmyCzService extends AbstractService
 {
+	const ID = 25;
 	const NAME = 'Firmy.cz';
 
 	const LINK = 'https://firmy.cz';

--- a/src/libs/BetterLocation/Service/FoursquareService.php
+++ b/src/libs/BetterLocation/Service/FoursquareService.php
@@ -10,6 +10,7 @@ use App\Foursquare\Types\VenueType;
 
 final class FoursquareService extends AbstractService
 {
+	const ID = 22;
 	const NAME = 'Foursquare';
 
 	const LINK = Client::LINK;

--- a/src/libs/BetterLocation/Service/GeocachingService.php
+++ b/src/libs/BetterLocation/Service/GeocachingService.php
@@ -20,6 +20,7 @@ use Tracy\ILogger;
 
 final class GeocachingService extends AbstractService
 {
+	const ID = 26;
 	const NAME = 'Geocaching';
 
 	const LINK = Client::LINK;

--- a/src/libs/BetterLocation/Service/GeohashService.php
+++ b/src/libs/BetterLocation/Service/GeohashService.php
@@ -15,6 +15,7 @@ use Lvht\GeoHash;
  */
 final class GeohashService extends AbstractService
 {
+	const ID = 19;
 	const NAME = 'Geohash';
 
 	const LINK = 'http://geohash.org';

--- a/src/libs/BetterLocation/Service/GlympseService.php
+++ b/src/libs/BetterLocation/Service/GlympseService.php
@@ -18,6 +18,7 @@ use Tracy\ILogger;
 
 final class GlympseService extends AbstractService
 {
+	const ID = 27;
 	const NAME = 'Glympse';
 
 	const LINK = 'https://glympse.com';

--- a/src/libs/BetterLocation/Service/GoogleMapsService.php
+++ b/src/libs/BetterLocation/Service/GoogleMapsService.php
@@ -12,6 +12,7 @@ use Nette\Utils\Strings;
 
 final class GoogleMapsService extends AbstractService
 {
+	const ID = 2;
 	const NAME = 'Google';
 
 	const LINK = 'https://www.google.cz/maps/place/%1$f,%2$f?q=%1$f,%2$f';

--- a/src/libs/BetterLocation/Service/HereWeGoService.php
+++ b/src/libs/BetterLocation/Service/HereWeGoService.php
@@ -12,6 +12,7 @@ use Nette\Utils\Arrays;
 
 final class HereWeGoService extends AbstractService
 {
+	const ID = 5;
 	const NAME = 'HERE WeGo';
 	const NAME_SHORT = 'HERE';
 

--- a/src/libs/BetterLocation/Service/IngressIntelService.php
+++ b/src/libs/BetterLocation/Service/IngressIntelService.php
@@ -12,6 +12,7 @@ use Tracy\Debugger;
 
 final class IngressIntelService extends AbstractService
 {
+	const ID = 9;
 	const NAME = 'Ingress';
 
 	const TYPE_MAP = 'map';

--- a/src/libs/BetterLocation/Service/IngressMosaicService.php
+++ b/src/libs/BetterLocation/Service/IngressMosaicService.php
@@ -12,6 +12,7 @@ use Nette\Utils\Arrays;
 
 final class IngressMosaicService extends AbstractService
 {
+	const ID = 23;
 	const NAME = 'IngressMosaic';
 	const LINK = Client::LINK;
 	const RE_PATH = '/^\/mosaic\/([0-9]+)$/';

--- a/src/libs/BetterLocation/Service/MapyCzService.php
+++ b/src/libs/BetterLocation/Service/MapyCzService.php
@@ -13,6 +13,7 @@ use Tracy\Debugger;
 
 final class MapyCzService extends AbstractService
 {
+	const ID = 8;
 	const NAME = 'Mapy.cz';
 	const LINK = 'https://mapy.cz/zakladni?y=%1$f&x=%2$f&source=coor&id=%2$f%%2C%1$f';
 

--- a/src/libs/BetterLocation/Service/OpenLocationCodeService.php
+++ b/src/libs/BetterLocation/Service/OpenLocationCodeService.php
@@ -9,6 +9,7 @@ use OpenLocationCode\OpenLocationCode;
 
 final class OpenLocationCodeService extends AbstractService
 {
+	const ID = 17;
 	const NAME = 'OpenLocationCode';
 	const NAME_SHORT = 'OLC';
 

--- a/src/libs/BetterLocation/Service/OpenStreetMapService.php
+++ b/src/libs/BetterLocation/Service/OpenStreetMapService.php
@@ -12,6 +12,7 @@ use Nette\Utils\Strings;
 
 final class OpenStreetMapService extends AbstractService
 {
+	const ID = 7;
 	const NAME = 'OpenStreetMap';
 	const NAME_SHORT = 'OSM';
 

--- a/src/libs/BetterLocation/Service/OrganicMapsService.php
+++ b/src/libs/BetterLocation/Service/OrganicMapsService.php
@@ -12,6 +12,7 @@ use App\Utils\Ge0Code;
  */
 final class OrganicMapsService extends AbstractService
 {
+	const ID = 18;
 	const NAME = 'Organic Maps';
 
 	const LINK = 'https://organicmaps.app';

--- a/src/libs/BetterLocation/Service/OsmAndService.php
+++ b/src/libs/BetterLocation/Service/OsmAndService.php
@@ -9,6 +9,7 @@ use Nette\Utils\Arrays;
 
 final class OsmAndService extends AbstractService
 {
+	const ID = 15;
 	const NAME = 'OsmAnd';
 
 	const LINK = 'https://osmand.net';

--- a/src/libs/BetterLocation/Service/RopikyNetService.php
+++ b/src/libs/BetterLocation/Service/RopikyNetService.php
@@ -11,6 +11,7 @@ use Nette\Utils\Arrays;
 
 final class RopikyNetService extends AbstractService
 {
+	const ID = 28;
 	const NAME = 'Řopíky.net';
 
 	const LINK = 'https://ropiky.net';

--- a/src/libs/BetterLocation/Service/SumavaCzService.php
+++ b/src/libs/BetterLocation/Service/SumavaCzService.php
@@ -12,6 +12,7 @@ use Tracy\Debugger;
 
 final class SumavaCzService extends AbstractService
 {
+	const ID = 29;
 	const NAME = 'Šumava.cz';
 
 	const LINK = 'http://www.sumava.cz';

--- a/src/libs/BetterLocation/Service/SygicService.php
+++ b/src/libs/BetterLocation/Service/SygicService.php
@@ -4,6 +4,7 @@ namespace App\BetterLocation\Service;
 
 final class SygicService extends AbstractService
 {
+	const ID = 4;
 	const NAME = 'Sygic';
 
 	const LINK = 'https://sygic.com';

--- a/src/libs/BetterLocation/Service/WazeService.php
+++ b/src/libs/BetterLocation/Service/WazeService.php
@@ -10,6 +10,7 @@ use App\Utils\Strict;
 
 final class WazeService extends AbstractService
 {
+	const ID = 3;
 	const NAME = 'Waze';
 
 	const LINK = 'https://www.waze.com';

--- a/src/libs/BetterLocation/Service/WhatThreeWordService.php
+++ b/src/libs/BetterLocation/Service/WhatThreeWordService.php
@@ -9,6 +9,7 @@ use Nette\Utils\Arrays;
 
 final class WhatThreeWordService extends AbstractService
 {
+	const ID = 30;
 	const NAME = 'What3Words';
 	const NAME_SHORT = 'W3W';
 

--- a/src/libs/BetterLocation/Service/WikipediaService.php
+++ b/src/libs/BetterLocation/Service/WikipediaService.php
@@ -11,6 +11,7 @@ use Nette\Utils\Strings;
 
 final class WikipediaService extends AbstractService
 {
+	const ID = 20;
 	const NAME = 'Wikipedia';
 
 	const LINK = 'https://wikipedia.org';

--- a/src/libs/BetterLocation/Service/ZanikleObceCzService.php
+++ b/src/libs/BetterLocation/Service/ZanikleObceCzService.php
@@ -13,6 +13,7 @@ use Tracy\ILogger;
 
 final class ZanikleObceCzService extends AbstractService
 {
+	const ID = 31;
 	const NAME = 'ZanikleObce.cz';
 
 	const LINK = 'http://zanikleobce.cz';

--- a/src/libs/BetterLocation/Service/ZniceneKostelyCzService.php
+++ b/src/libs/BetterLocation/Service/ZniceneKostelyCzService.php
@@ -11,6 +11,7 @@ use App\Utils\Strict;
 
 final class ZniceneKostelyCzService extends AbstractService
 {
+	const ID = 32;
 	const NAME = 'ZniceneKostely.cz';
 
 	const LINK = 'http://znicenekostely.cz';

--- a/src/libs/BetterLocation/ServicesManager.php
+++ b/src/libs/BetterLocation/ServicesManager.php
@@ -44,47 +44,47 @@ class ServicesManager
 
 	public function __construct()
 	{
-		$this->services[] = BetterLocationService::class;
-		$this->services[] = WGS84DegreesService::class;
-		$this->services[] = WGS84DegreesMinutesService::class;
-		$this->services[] = WGS84DegreesMinutesSecondsService::class;
-		$this->services[] = MGRSService::class;
-		$this->services[] = USNGService::class;
-		$this->services[] = GoogleMapsService::class;
-		$this->services[] = WazeService::class;
-		$this->services[] = SygicService::class;
-		$this->services[] = HereWeGoService::class;
-		$this->services[] = OpenStreetMapService::class;
-		$this->services[] = FacebookService::class;
-		$this->services[] = MapyCzService::class;
-		$this->services[] = IngressIntelService::class;
-		$this->services[] = OsmAndService::class;
-		$this->services[] = DrobnePamatkyCzService::class;
-		$this->services[] = OpenLocationCodeService::class;
-		$this->services[] = GeohashService::class;
-		$this->services[] = OrganicMapsService::class;
-		$this->services[] = WikipediaService::class;
-		$this->services[] = DuckDuckGoService::class;
+		$this->services[BetterLocationService::ID] = BetterLocationService::class;
+		$this->services[WGS84DegreesService::ID] = WGS84DegreesService::class;
+		$this->services[WGS84DegreesMinutesService::ID] = WGS84DegreesMinutesService::class;
+		$this->services[WGS84DegreesMinutesSecondsService::ID] = WGS84DegreesMinutesSecondsService::class;
+		$this->services[MGRSService::ID] = MGRSService::class;
+		$this->services[USNGService::ID] = USNGService::class;
+		$this->services[GoogleMapsService::ID] = GoogleMapsService::class;
+		$this->services[WazeService::ID] = WazeService::class;
+		$this->services[SygicService::ID] = SygicService::class;
+		$this->services[HereWeGoService::ID] = HereWeGoService::class;
+		$this->services[OpenStreetMapService::ID] = OpenStreetMapService::class;
+		$this->services[FacebookService::ID] = FacebookService::class;
+		$this->services[MapyCzService::ID] = MapyCzService::class;
+		$this->services[IngressIntelService::ID] = IngressIntelService::class;
+		$this->services[OsmAndService::ID] = OsmAndService::class;
+		$this->services[DrobnePamatkyCzService::ID] = DrobnePamatkyCzService::class;
+		$this->services[OpenLocationCodeService::ID] = OpenLocationCodeService::class;
+		$this->services[GeohashService::ID] = GeohashService::class;
+		$this->services[OrganicMapsService::ID] = OrganicMapsService::class;
+		$this->services[WikipediaService::ID] = WikipediaService::class;
+		$this->services[DuckDuckGoService::ID] = DuckDuckGoService::class;
 		if (Config::isFoursquare()) {
-			$this->services[] = FoursquareService::class;
+			$this->services[FoursquareService::ID] = FoursquareService::class;
 		}
 		if (Config::isIngressMosaic()) {
-			$this->services[] = IngressMosaicService::class;
+			$this->services[IngressMosaicService::ID] = IngressMosaicService::class;
 		}
 		if (is_null(Config::GEOCACHING_COOKIE) === false) {
-			$this->services[] = GeocachingService::class;
+			$this->services[GeocachingService::ID] = GeocachingService::class;
 		}
 		if (is_null(Config::W3W_API_KEY) === false) {
-			$this->services[] = WhatThreeWordService::class;
+			$this->services[WhatThreeWordService::ID] = WhatThreeWordService::class;
 		}
 		if (Config::isGlympse()) {
-			$this->services[] = GlympseService::class;
+			$this->services[GlympseService::ID] = GlympseService::class;
 		}
-		$this->services[] = RopikyNetService::class;
-		$this->services[] = ZanikleObceCzService::class;
-		$this->services[] = ZniceneKostelyCzService::class;
-		$this->services[] = SumavaCzService::class;
-		$this->services[] = FevGamesService::class;
+		$this->services[RopikyNetService::ID] = RopikyNetService::class;
+		$this->services[ZanikleObceCzService::ID] = ZanikleObceCzService::class;
+		$this->services[ZniceneKostelyCzService::ID] = ZniceneKostelyCzService::class;
+		$this->services[SumavaCzService::ID] = SumavaCzService::class;
+		$this->services[FevGamesService::ID] = FevGamesService::class;
 	}
 
 	public function iterate(string $input): BetterLocationCollection
@@ -113,5 +113,11 @@ class ServicesManager
 	public function getServices(): array
 	{
 		return $this->services;
+	}
+
+	/** @return int[] */
+	public function getServicesIds(): array
+	{
+		return array_keys($this->services);
 	}
 }

--- a/src/libs/BetterLocation/ServicesManager.php
+++ b/src/libs/BetterLocation/ServicesManager.php
@@ -10,6 +10,7 @@ use App\BetterLocation\Service\Coordinates\WGS84DegreesMinutesSecondsService;
 use App\BetterLocation\Service\Coordinates\WGS84DegreesMinutesService;
 use App\BetterLocation\Service\Coordinates\WGS84DegreesService;
 use App\BetterLocation\Service\DrobnePamatkyCzService;
+use App\BetterLocation\Service\DuckDuckGoService;
 use App\BetterLocation\Service\FacebookService;
 use App\BetterLocation\Service\FevGamesService;
 use App\BetterLocation\Service\FoursquareService;
@@ -63,7 +64,7 @@ class ServicesManager
 		$this->services[] = GeohashService::class;
 		$this->services[] = OrganicMapsService::class;
 		$this->services[] = WikipediaService::class;
-//		$this->services[] = DuckDuckGoService::class; // currently not supported
+		$this->services[] = DuckDuckGoService::class;
 		if (Config::isFoursquare()) {
 			$this->services[] = FoursquareService::class;
 		}

--- a/src/libs/Chat.php
+++ b/src/libs/Chat.php
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use App\TelegramCustomWrapper\BetterLocationMessageSettings;
+
 class Chat
 {
 	private $db;
@@ -10,6 +12,8 @@ class Chat
 	private $telegramChatId;
 	private $telegramChatName;
 	private $telegramChatType;
+	/** @var BetterLocationMessageSettings */
+	private $messageSettings;
 
 	public function __construct(int $telegramChatId, string $telegramChatType, ?string $telegramChatName = null)
 	{
@@ -90,5 +94,13 @@ class Chat
 	public function getTelegramChatName(): ?string
 	{
 		return $this->telegramChatName;
+	}
+
+	public function getMessageSettings(): BetterLocationMessageSettings
+	{
+		if ($this->messageSettings === null) {
+			$this->messageSettings = BetterLocationMessageSettings::loadByChatId($this->id);
+		}
+		return $this->messageSettings;
 	}
 }

--- a/src/libs/Dashboard/Tester.php
+++ b/src/libs/Dashboard/Tester.php
@@ -3,6 +3,7 @@
 namespace App\Dashboard;
 
 use App\BetterLocation\BetterLocationCollection;
+use App\TelegramCustomWrapper\BetterLocationMessageSettings;
 use App\TelegramCustomWrapper\ProcessedMessageResult;
 use App\TelegramCustomWrapper\TelegramHelper;
 use unreal4u\TelegramAPI\Telegram\Types\Inline\Keyboard\Button;
@@ -39,7 +40,7 @@ class Tester
 	{
 		$entities = TelegramHelper::generateEntities($this->getInput());
 		$collection = BetterLocationCollection::fromTelegramMessage($this->getInput(), $entities);
-		$processedCollection = new ProcessedMessageResult($collection);
+		$processedCollection = new ProcessedMessageResult($collection, new BetterLocationMessageSettings());
 		$processedCollection->process(true);
 		if ($collection->count() > 0) {
 			$this->outputText = trim($processedCollection->getText());

--- a/src/libs/TelegramCustomWrapper/BetterLocationMessageSettings.php
+++ b/src/libs/TelegramCustomWrapper/BetterLocationMessageSettings.php
@@ -4,16 +4,30 @@ namespace App\TelegramCustomWrapper;
 
 use App\BetterLocation\Service\AbstractService;
 use App\BetterLocation\Service\BetterLocationService;
+use App\BetterLocation\Service\DuckDuckGoService;
 use App\BetterLocation\Service\GoogleMapsService;
 use App\BetterLocation\Service\HereWeGoService;
 use App\BetterLocation\Service\MapyCzService;
+use App\BetterLocation\Service\OpenStreetMapService;
 use App\BetterLocation\Service\OsmAndService;
 use App\BetterLocation\Service\WazeService;
+use App\BetterLocation\ServicesManager;
+use App\Factory;
+use App\Utils\Strict;
 
 class BetterLocationMessageSettings
 {
-	/** @var AbstractService[] $services */
-	public $linkServices = [
+	const TYPE_SHARE = 1;
+	const TYPE_DRIVE = 2;
+	const TYPE_SCREENSHOT = 3;
+
+	const TYPES = [
+		self::TYPE_SHARE,
+		self::TYPE_DRIVE,
+		self::TYPE_SCREENSHOT,
+	];
+
+	const DEFAULT_SHARE_SERVICES = [
 		BetterLocationService::class,
 		GoogleMapsService::class,
 		MapyCzService::class,
@@ -22,13 +36,108 @@ class BetterLocationMessageSettings
 		HereWeGoService::class,
 		OpenStreetMapService::class,
 	];
-	/** @var AbstractService[] $services */
-	public $buttonServices = [
+	const DEFAULT_DRIVE_SERVICES = [
 		GoogleMapsService::class,
 		WazeService::class,
 		HereWeGoService::class,
 		OsmAndService::class,
 	];
-	public $screenshotLinkService = MapyCzService::class;
-	public $address = true;
+	const DEFAULT_SCREENSHOT_SERVICE = MapyCzService::class;
+
+	/** @var AbstractService[] $services */
+	private $linkServices;
+	/** @var AbstractService[] $services */
+	private $buttonServices;
+	private $screenshotLinkService;
+	private $address;
+
+	public function __construct(
+		array $shareServices = self::DEFAULT_SHARE_SERVICES,
+		array $buttonServices = self::DEFAULT_DRIVE_SERVICES,
+		string $screenshotLinkService = self::DEFAULT_SCREENSHOT_SERVICE,
+		bool $address = false
+	)
+	{
+		$this->linkServices = $shareServices;
+		$this->buttonServices = $buttonServices;
+		$this->screenshotLinkService = $screenshotLinkService;
+		$this->address = $address;
+	}
+
+	public static function loadByChatId(int $chatId): self
+	{
+		$db = Factory::Database();
+		$rows = $db->query('SELECT * FROM better_location_chat_services WHERE chat_id = ? ORDER BY type, service_id DESC', $chatId)->fetchAll();
+		$result = new self();
+		$services = (new ServicesManager())->getServices();
+		if ($filtered = self::filterByState($services, $rows, self::TYPE_SHARE)) {
+			$result->setLinkServices($filtered);
+		}
+		if ($filtered = self::filterByState($services, $rows, self::TYPE_DRIVE)) {
+			$result->setButtonServices($filtered);
+		}
+		if ($filtered = self::filterByState($services, $rows, self::TYPE_SCREENSHOT)) {
+			$result->setScreenshotLinkService($filtered[0]);
+		}
+		return $result;
+	}
+
+	private static function filterByState(array $services, array $rows, int $serviceType)
+	{
+		$filteredRows = array_filter($rows, function ($row) use ($serviceType) {
+			return Strict::intval($row['type']) === $serviceType;
+		});
+		$result = [];
+		foreach ($filteredRows as $filteredRow) {
+			$serviceId = $filteredRow['service_id'];
+			$result[] = $services[$serviceId];
+		}
+		return $result;
+	}
+
+	/** @param AbstractService[] $services */
+	public function setLinkServices(array $services): void
+	{
+		// Ensure, that first service is always BetterLocation, even if it is already set
+		$services = array_unique(array_merge([BetterLocationService::class], $services));
+		$this->linkServices = $services;
+	}
+
+	/** @param AbstractService[] $services */
+	public function setButtonServices(array $services): void
+	{
+		$this->buttonServices = $services;
+	}
+
+	public function setScreenshotLinkService(string $service): void
+	{
+		$this->screenshotLinkService = $service;
+	}
+
+	public function setAddress(bool $address): void
+	{
+		$this->address = $address;
+	}
+
+	/** @return AbstractService[] */
+	public function getLinkServices(): array
+	{
+		return $this->linkServices;
+	}
+
+	/** @return AbstractService[] */
+	public function getButtonServices(): array
+	{
+		return $this->buttonServices;
+	}
+
+	public function getScreenshotLinkService(): string
+	{
+		return $this->screenshotLinkService;
+	}
+
+	public function showAddress(): bool
+	{
+		return $this->address;
+	}
 }

--- a/src/libs/TelegramCustomWrapper/BetterLocationMessageSettings.php
+++ b/src/libs/TelegramCustomWrapper/BetterLocationMessageSettings.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace App\TelegramCustomWrapper;
+
+use App\BetterLocation\Service\AbstractService;
+use App\BetterLocation\Service\BetterLocationService;
+use App\BetterLocation\Service\GoogleMapsService;
+use App\BetterLocation\Service\HereWeGoService;
+use App\BetterLocation\Service\MapyCzService;
+use App\BetterLocation\Service\OsmAndService;
+use App\BetterLocation\Service\WazeService;
+
+class BetterLocationMessageSettings
+{
+	/** @var AbstractService[] $services */
+	public $linkServices = [
+		BetterLocationService::class,
+		GoogleMapsService::class,
+		MapyCzService::class,
+		DuckDuckGoService::class,
+		WazeService::class,
+		HereWeGoService::class,
+		OpenStreetMapService::class,
+	];
+	/** @var AbstractService[] $services */
+	public $buttonServices = [
+		GoogleMapsService::class,
+		WazeService::class,
+		HereWeGoService::class,
+		OsmAndService::class,
+	];
+	public $screenshotLinkService = MapyCzService::class;
+	public $address = true;
+}

--- a/src/libs/TelegramCustomWrapper/BetterLocationMessageSettings.php
+++ b/src/libs/TelegramCustomWrapper/BetterLocationMessageSettings.php
@@ -89,8 +89,9 @@ class BetterLocationMessageSettings
 		});
 		$result = [];
 		foreach ($filteredRows as $filteredRow) {
+			$order = Strict::intval($filteredRow['order']);
 			$serviceId = $filteredRow['service_id'];
-			$result[] = $services[$serviceId];
+			$result[$order] = $services[$serviceId];
 		}
 		return $result;
 	}
@@ -99,13 +100,15 @@ class BetterLocationMessageSettings
 	public function setLinkServices(array $services): void
 	{
 		// Ensure, that first service is always BetterLocation, even if it is already set
-		$services = array_unique(array_merge([BetterLocationService::class], $services));
+		$services = array_unique([BetterLocationService::class] + $services);
+		ksort($services, SORT_NUMERIC);
 		$this->linkServices = $services;
 	}
 
 	/** @param AbstractService[] $services */
 	public function setButtonServices(array $services): void
 	{
+		ksort($services, SORT_NUMERIC);
 		$this->buttonServices = $services;
 	}
 

--- a/src/libs/TelegramCustomWrapper/Events/Button/RefreshButton.php
+++ b/src/libs/TelegramCustomWrapper/Events/Button/RefreshButton.php
@@ -97,7 +97,7 @@ class RefreshButton extends Button
 				$this->telegramUpdateDb->getOriginalUpdateObject()->message->text,
 				$this->telegramUpdateDb->getOriginalUpdateObject()->message->entities,
 			);
-			$processedCollection = new ProcessedMessageResult($collection);
+			$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 			$processedCollection->setAutorefresh($autorefreshEnabled);
 			$processedCollection->process();
 			$text = $processedCollection->getText();

--- a/src/libs/TelegramCustomWrapper/Events/Command/StartCommand.php
+++ b/src/libs/TelegramCustomWrapper/Events/Command/StartCommand.php
@@ -64,7 +64,7 @@ class StartCommand extends Command
 		} else {
 			try {
 				$collection = WGS84DegreesService::processStatic($lat . ',' . $lon)->getCollection();
-				$processedCollection = new ProcessedMessageResult($collection);
+				$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 				$processedCollection->process();
 				$this->reply($processedCollection->getText(), $processedCollection->getMarkup(1), ['disable_web_page_preview' => !$this->user->settings()->getPreview()]);
 			} catch (\Throwable $exception) {

--- a/src/libs/TelegramCustomWrapper/Events/Edit/LocationEdit.php
+++ b/src/libs/TelegramCustomWrapper/Events/Edit/LocationEdit.php
@@ -44,7 +44,7 @@ class LocationEdit extends Edit
 
 		$collection = $this->getCollection();
 		if ($messageToRefresh = TelegramUpdateDb::loadByOriginalMessageId($this->getChatId(), $this->getMessageId())) {
-			$processedCollection = new ProcessedMessageResult($collection);
+			$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 			$processedCollection->process();
 			$text = $processedCollection->getText();
 			$text .= sprintf('%s Last live location from %s', Icons::REFRESH, (new \DateTimeImmutable())->format(Config::DATETIME_FORMAT_ZONE));

--- a/src/libs/TelegramCustomWrapper/Events/Events.php
+++ b/src/libs/TelegramCustomWrapper/Events/Events.php
@@ -232,7 +232,7 @@ abstract class Events
 		$text .= sprintf('I\'m a simple but smart bot to catch all possible location formats in any chats you invite me to, and generate links to your favourite location services such as Google maps, Waze, OpenStreetMap etc.') . PHP_EOL;
 		$text .= sprintf('For example, if you send a message containing the coordinates "<code>%f,%f</code>" or the link "%s" I will respond with this:', $lat, $lon, $wazeLink) . PHP_EOL;
 		$text .= PHP_EOL;
-		$text .= $betterLocationWaze->generateMessage();
+		$text .= $betterLocationWaze->generateMessage($this->getMessageSettings());
 		// @TODO newline is filled in $result (yeah, it shouldn't be like that..)
 		$text .= sprintf('%s <b>Formats I can read:</b>', Icons::FEATURES) . PHP_EOL;
 		$text .= sprintf('- coordinates: <a href="%s">WGS84</a>, <a href="%s">USNG</a>, <a href="%s">MGRS</a>, <a href="%s">UTM</a>, ...',
@@ -350,7 +350,7 @@ abstract class Events
 					count($this->user->getFavourites())
 				) . PHP_EOL;
 			foreach ($this->user->getFavourites() as $favourite) {
-				$text .= $favourite->generateMessage();
+				$text .= $favourite->generateMessage($this->getMessageSettings());
 
 				$shareFavouriteButton = new Button();
 				$shareFavouriteButton->text = sprintf('Share %s', $favourite->getPrefixMessage());
@@ -391,7 +391,7 @@ abstract class Events
 	protected function processSettings(bool $inline = false)
 	{
 		$collection = WazeService::processStatic(WazeService::getLink(50.087451, 14.420671))->getCollection();
-		$processedCollection = new ProcessedMessageResult($collection);
+		$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 		$processedCollection->process();
 
 		$text = sprintf('%s <b>User settings</b> for @%s. Example message:', Icons::SETTINGS, Config::TELEGRAM_BOT_NAME) . PHP_EOL;

--- a/src/libs/TelegramCustomWrapper/Events/Events.php
+++ b/src/libs/TelegramCustomWrapper/Events/Events.php
@@ -7,6 +7,7 @@ use App\BetterLocation\Service\WazeService;
 use App\Chat;
 use App\Config;
 use App\Icons;
+use App\TelegramCustomWrapper\BetterLocationMessageSettings;
 use App\TelegramCustomWrapper\Events\Button\FavouritesButton;
 use App\TelegramCustomWrapper\Events\Button\HelpButton;
 use App\TelegramCustomWrapper\Events\Button\SettingsButton;
@@ -73,6 +74,15 @@ abstract class Events
 	public function getChat(): Telegram\Types\Chat
 	{
 		return $this->getMessage()->chat;
+	}
+
+	public final function getMessageSettings(): BetterLocationMessageSettings
+	{
+		if ($this->chat) {
+			return $this->chat->getMessageSettings();
+		} else {
+			return $this->user->getMessageSettings();
+		}
 	}
 
 	public function getFrom(): Telegram\Types\User

--- a/src/libs/TelegramCustomWrapper/Events/Special/AddedToChatEvent.php
+++ b/src/libs/TelegramCustomWrapper/Events/Special/AddedToChatEvent.php
@@ -22,16 +22,16 @@ class AddedToChatEvent extends Special
 		$betterLocationWaze = WazeService::processStatic($wazeLink)->getFirst();
 
 		$markup = new Markup();
-		$markup->inline_keyboard = [$betterLocationWaze->generateDriveButtons()];
+		$markup->inline_keyboard = [$betterLocationWaze->generateDriveButtons($this->getMessageSettings())];
 
 		$text = sprintf('%s Hi <b>%s</b>, @%s here!', Icons::LOCATION, $this->getChatDisplayname(), Config::TELEGRAM_BOT_NAME) . PHP_EOL;
 		$text .= sprintf('Thanks for adding me to this chat. I will be checking every message here if it contains any form of location (coordinates, links, photos with EXIF...) and send a nicely formatted message. More info in %s.', HelpCommand::getCmd(!$this->isPm())) . PHP_EOL;
 		$text .= sprintf('For example if you send %s I will respond with this:', $wazeLink) . PHP_EOL;
-		$text .= $betterLocationWaze->generateMessage();
+		$text .= $betterLocationWaze->generateMessage($this->getMessageSettings());
 		if ($betterLocationLocalGroup = $this->getChatLocation()) {
 			$text .= sprintf('I noticed, that this is local group so here is nice message:') . PHP_EOL;
-			$text .= $betterLocationLocalGroup->generateMessage();
-			$markup->inline_keyboard[] = $betterLocationLocalGroup->generateDriveButtons();
+			$text .= $betterLocationLocalGroup->generateMessage($this->getMessageSettings());
+			$markup->inline_keyboard[] = $betterLocationLocalGroup->generateDriveButtons($this->getMessageSettings());
 		}
 
 		$this->reply($text, $markup, [

--- a/src/libs/TelegramCustomWrapper/Events/Special/FileEvent.php
+++ b/src/libs/TelegramCustomWrapper/Events/Special/FileEvent.php
@@ -59,7 +59,7 @@ class FileEvent extends Special
 	public function handleWebhookUpdate()
 	{
 		$collection = $this->getCollection();
-		$processedCollection = new ProcessedMessageResult($collection);
+		$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 		$processedCollection->process();
 		if ($collection->count() > 0) {
 			if ($this->user->settings()->getSendNativeLocation()) {

--- a/src/libs/TelegramCustomWrapper/Events/Special/InlineQueryEvent.php
+++ b/src/libs/TelegramCustomWrapper/Events/Special/InlineQueryEvent.php
@@ -167,9 +167,9 @@ class InlineQueryEvent extends Special
 		$inlineQueryResult->thumb_url = MapyCzService::getScreenshotLink($betterLocation->getLat(), $betterLocation->getLon());
 		$inlineQueryResult->reply_markup = new Markup();
 
-		$inlineQueryResult->reply_markup->inline_keyboard = [$betterLocation->generateDriveButtons()];
+		$inlineQueryResult->reply_markup->inline_keyboard = [$betterLocation->generateDriveButtons($this->getMessageSettings())];
 		$inlineQueryResult->input_message_content = new Text();
-		$inlineQueryResult->input_message_content->message_text = TelegramHelper::getMessagePrefix($betterLocation->getStaticMapUrl()) . $betterLocation->generateMessage();
+		$inlineQueryResult->input_message_content->message_text = TelegramHelper::getMessagePrefix($betterLocation->getStaticMapUrl()) . $betterLocation->generateMessage($this->getMessageSettings());
 		$inlineQueryResult->input_message_content->parse_mode = 'HTML';
 		$inlineQueryResult->input_message_content->disable_web_page_preview = !$this->user->settings()->getPreview();
 		return $inlineQueryResult;
@@ -187,13 +187,13 @@ class InlineQueryEvent extends Special
 		$inlineQueryResult->title = strip_tags($inlineTitle);
 		$inlineQueryResult->thumb_url = MapyCzService::getScreenshotLink($betterLocation->getLat(), $betterLocation->getLon());
 		$inlineQueryResult->reply_markup = new Markup();
-		$inlineQueryResult->reply_markup->inline_keyboard = [$betterLocation->generateDriveButtons()];
+		$inlineQueryResult->reply_markup->inline_keyboard = [$betterLocation->generateDriveButtons($this->getMessageSettings())];
 		return $inlineQueryResult;
 	}
 
 	private function getAllLocationsInlineQueryResult(BetterLocationCollection $collection): Inline\Query\Result\Article
 	{
-		$processedCollection = new ProcessedMessageResult($collection);
+		$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 		$processedCollection->process(true);
 
 		$inlineQueryResult = new Inline\Query\Result\Article();

--- a/src/libs/TelegramCustomWrapper/Events/Special/LocationEvent.php
+++ b/src/libs/TelegramCustomWrapper/Events/Special/LocationEvent.php
@@ -49,7 +49,7 @@ class LocationEvent extends Special
 		}
 
 		$collection = $this->getCollection();
-		$processedCollection = new ProcessedMessageResult($collection);
+		$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 		$processedCollection->process();
 		if ($collection->count() > 0) {
 			$markup = $processedCollection->getMarkup(1, false);

--- a/src/libs/TelegramCustomWrapper/Events/Special/MessageEvent.php
+++ b/src/libs/TelegramCustomWrapper/Events/Special/MessageEvent.php
@@ -29,7 +29,7 @@ class MessageEvent extends Special
 				Debugger::log($exception, Debugger::EXCEPTION);
 			}
 		}
-		$processedCollection = new ProcessedMessageResult($collection);
+		$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 		$processedCollection->process();
 		if ($collection->count() > 0) {
 			if ($this->user->settings()->getSendNativeLocation()) {

--- a/src/libs/TelegramCustomWrapper/Events/Special/PhotoEvent.php
+++ b/src/libs/TelegramCustomWrapper/Events/Special/PhotoEvent.php
@@ -19,7 +19,7 @@ class PhotoEvent extends Special
 	public function handleWebhookUpdate()
 	{
 		$collection = $this->getCollection();
-		$processedCollection = new ProcessedMessageResult($collection);
+		$processedCollection = new ProcessedMessageResult($collection, $this->getMessageSettings());
 		$processedCollection->process();
 		if ($collection->count() > 0) {
 			if ($this->user->settings()->getSendNativeLocation()) {

--- a/src/libs/TelegramCustomWrapper/ProcessedMessageResult.php
+++ b/src/libs/TelegramCustomWrapper/ProcessedMessageResult.php
@@ -21,9 +21,13 @@ class ProcessedMessageResult
 
 	private $validLocationsCount = 0;
 
-	public function __construct(BetterLocationCollection $collection)
+	/** @var BetterLocationMessageSettings */
+	private $messageSettings;
+
+	public function __construct(BetterLocationCollection $collection, BetterLocationMessageSettings $messageSettings)
 	{
 		$this->collection = $collection;
+		$this->messageSettings = $messageSettings;
 	}
 
 	public function setAutorefresh(bool $enabled): void
@@ -35,8 +39,8 @@ class ProcessedMessageResult
 	{
 		foreach ($this->collection->getLocations() as $betterLocation) {
 			$betterLocation->generateAddress();
-			$this->resultText .= $betterLocation->generateMessage();
-			$this->buttons[] = $betterLocation->generateDriveButtons();
+			$this->resultText .= $betterLocation->generateMessage($this->messageSettings);
+			$this->buttons[] = $betterLocation->generateDriveButtons($this->messageSettings);
 			$this->validLocationsCount++;
 		}
 		foreach ($this->collection->getErrors() as $error) {

--- a/src/libs/User.php
+++ b/src/libs/User.php
@@ -5,6 +5,7 @@ namespace App;
 use App\BetterLocation\BetterLocation;
 use App\BetterLocation\BetterLocationCollection;
 use App\BetterLocation\Service\Exceptions\InvalidLocationException;
+use App\TelegramCustomWrapper\BetterLocationMessageSettings;
 use App\Utils\Coordinates;
 use Nette\Utils\Strings;
 
@@ -25,6 +26,9 @@ class User
 	private $favourites;
 	/** @var BetterLocationCollection */
 	private $favouritesDeleted;
+
+	/** @var ?BetterLocationMessageSettings */
+	private $messageSettings;
 
 	public function __construct(int $telegramId, string $telegramDisplayname)
 	{
@@ -234,5 +238,13 @@ class User
 	public function settings(): UserSettings
 	{
 		return $this->settings;
+	}
+
+	public function getMessageSettings(): BetterLocationMessageSettings
+	{
+		if ($this->messageSettings === null) {
+			$this->messageSettings = BetterLocationMessageSettings::loadByChatId($this->id);
+		}
+		return $this->messageSettings;
 	}
 }

--- a/tests/BetterLocation/ServiceManagerTest.php
+++ b/tests/BetterLocation/ServiceManagerTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+
+final class ServiceManagerTest extends TestCase
+{
+	private static $manager;
+
+	public static function setUpBeforeClass(): void
+	{
+		self::$manager = new \App\BetterLocation\ServicesManager();
+	}
+
+	/**
+	 * Ensure, that all services are setup properly.
+	 */
+	public function testRequiredDataInServices(): void
+	{
+		$ids = [];
+		foreach(self::$manager->getServices() as $service) {
+			$reflection = new ReflectionClass($service);
+			$constantName = 'ID';
+			$this->assertTrue($reflection->hasConstant('NAME'), sprintf('Service class "%s" does not have required constant "NAME"', $service));
+			$this->assertTrue($reflection->hasConstant($constantName), sprintf('Service class "%s" does not have required constant "%s"', $service, $constantName));
+			$id = $reflection->getConstant($constantName);
+			$this->assertIsInt($id, sprintf('Service class "%s" has invalid constant %s "%s", must be int.', $service, $constantName, $id));
+			$this->assertGreaterThan(0, $id, sprintf('Service class "%s" has invalid constant %s "%s", must be positive int.', $service, $constantName, $id));
+			$duplicatedServiceName = $ids[$id] ?? null;
+			$this->assertNull($duplicatedServiceName, sprintf('ID %d is assigned to multiple services: "%s" and "%s"', $id, $duplicatedServiceName, $service));
+			$ids[$id] = $service;
+		}
+	}
+}

--- a/www/api/cron-refresh.php
+++ b/www/api/cron-refresh.php
@@ -43,7 +43,7 @@ if (isset($_GET['password']) && $_GET['password'] === \App\Config::CRON_PASSWORD
 				));
 				/** @var \App\BetterLocation\BetterLocationCollection $collection */
 				$collection = $event->getCollection();
-				$processedCollection = new ProcessedMessageResult($collection);
+				$processedCollection = new ProcessedMessageResult($collection, $event->getMessageSettings());
 				$processedCollection->setAutorefresh(true);
 				$processedCollection->process();
 


### PR DESCRIPTION
Added table and updated code to support loading services other than default. Updating this list is currently available only via direct access to database, so no GUI for now.

- each service has assigned numeric ID, which is (and will be) used as identificator in database
    - added test to control, if service has all required constants and uniqueness of IDs
- added class to maintain message settings (which services in links, which services in buttons and which service is used for screenshot) 